### PR TITLE
Alow use of ignore_modified_deleted and changed_fields.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Junipernetworks EDA source Collection Release Notes
 
 .. contents:: Topics
 
+v1.3.1
+=======
+
+Minor Changes
+-------------
+
+- Fix issue with igore_modified_deleted check not happening if changed_fields is set.
+- Fix "make test" target.
+
 v1.3.0
 =======
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ release-build: pipenv $(EDA_COLLECTION_ROOT)/requirements.txt
 
 build: $(EDA_COLLECTION_ROOT)/.eda-collection
 
-test: pipenv
+test: test-bin pipenv
 	pipenv run pytest
 
 $(EDA_COLLECTION_ROOT)/.eda-collection: $(EDA_COLLECTION_ROOT)/galaxy.yml  $(PY_FILES) Makefile

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@ namespace: junipernetworks
 
 name: eda
 
-version: 1.3.0
+version: 1.3.1
 
 readme: README.md
 

--- a/plugins/event_source/k8s.py
+++ b/plugins/event_source/k8s.py
@@ -625,7 +625,7 @@ class Watcher:
                                         self.changed_fields,
                                     )
                                     continue
-                            elif self.args.get(
+                            if self.args.get(
                                 "ignore_modified_deleted", False
                             ) and raw_object.get("metadata", {}).get(
                                 "deletionTimestamp"

--- a/plugins/event_source/test_k8s.py
+++ b/plugins/event_source/test_k8s.py
@@ -345,6 +345,7 @@ pod_manifest = {
         {
             "args": {
                 "kind": "Pod",
+                "changed_fields": ["metadata.resourceVersion"],
                 "kubeconfig": KUBECONFIG,
                 "test_events_qty": 4,
                 "heartbeat_interval": HEARTBEAT_INTERVAL,
@@ -366,10 +367,11 @@ pod_manifest = {
         {
             "args": {
                 "kind": "Pod",
+                "changed_fields": ["metadata.resourceVersion"],
+                "ignore_modified_deleted": True,
                 "kubeconfig": KUBECONFIG,
                 "test_events_qty": 3,
                 "heartbeat_interval": HEARTBEAT_INTERVAL,
-                "ignore_modified_deleted": True,
             },
             "created_watch_count": 1,
             "modified_watch_count": 1,


### PR DESCRIPTION
The combination of the features ignore_modified_deleted and changed_fields for a watch was failing. ignore_modified_deleting was ignored due to a logic error.